### PR TITLE
feat: restore lost changes and rename cwd to current_dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "cargo-readme"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +96,12 @@ dependencies = [
  "serde",
  "toml",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -138,6 +156,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,10 +267,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -184,10 +307,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
@@ -205,6 +363,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -237,13 +404,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "scc"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "scriptify"
 version = "0.1.0"
 dependencies = [
  "ansi-to-html",
  "anstyle",
  "cargo-readme",
+ "serial_test",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "serde"
@@ -273,6 +462,46 @@ checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ anstyle = "1.0.7"
 [dev-dependencies]
 ansi-to-html = "0.2.1"
 cargo-readme = "3.3.1"
+serial_test = "3.0"
 
 
 # 01_basics - Beginner examples

--- a/examples/02_intermediate/environment.rs
+++ b/examples/02_intermediate/environment.rs
@@ -63,21 +63,23 @@ fn working_directory_management() -> Result<()> {
 
     // Execute command in different directory
     echo!("\n🔄 Executing commands in different directories:");
-    cmd!("pwd").cwd("temp_work").run()?;
+    cmd!("pwd").current_dir("temp_work").run()?;
 
     // Chain operations in specific directory
     echo!("\n⛓️ Chained operations in specific directory:");
     cmd!("echo", "Hello from temp directory")
-        .cwd("temp_work")
+        .current_dir("temp_work")
         .run()?;
 
     // Create files in specific directory
     echo!("\n📄 Creating files in specific directory:");
-    let file_content = cmd!("echo", "File content").cwd("temp_work").output()?;
+    let file_content = cmd!("echo", "File content")
+        .current_dir("temp_work")
+        .output()?;
     fs::write("temp_work/test.txt", file_content)?;
 
     // Verify file creation
-    cmd!("ls", "-la").cwd("temp_work").run()?;
+    cmd!("ls", "-la").current_dir("temp_work").run()?;
 
     // Cleanup
     fs::remove_dir_all("temp_work")?;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -163,7 +163,8 @@ impl Cmd {
 
     /// Set an environment variable.
     pub fn env(mut self, key: impl AsRef<OsStr>, val: impl AsRef<OsStr>) -> Self {
-        self.envs.push((key.as_ref().to_os_string(), val.as_ref().to_os_string()));
+        self.envs
+            .push((key.as_ref().to_os_string(), val.as_ref().to_os_string()));
         self
     }
 
@@ -281,7 +282,10 @@ impl Cmd {
         }
 
         let mut child = cmd.spawn().map_err(|e| Error {
-            message: format!("Failed to spawn command: {}", self.program.to_string_lossy()),
+            message: format!(
+                "Failed to spawn command: {}",
+                self.program.to_string_lossy()
+            ),
             source: Some(e),
         })?;
 
@@ -319,21 +323,21 @@ impl Cmd {
         if let Some(cwd) = &self.cwd {
             echo = echo
                 .sput("cd:", BRIGHT_BLUE)
-                .sput(&cwd.to_string_lossy(), UNDERLINE_BRIGHT_BLUE);
+                .sput(cwd.to_string_lossy(), UNDERLINE_BRIGHT_BLUE);
         }
 
         for (key, val) in &self.envs {
             echo = echo
                 .sput("env:", BRIGHT_BLUE)
-                .sput(&key.to_string_lossy(), UNDERLINE_BRIGHT_BLUE)
+                .sput(key.to_string_lossy(), UNDERLINE_BRIGHT_BLUE)
                 .put("=")
-                .sput(&val.to_string_lossy(), UNDERLINE_BRIGHT_BLUE);
+                .sput(val.to_string_lossy(), UNDERLINE_BRIGHT_BLUE);
         }
 
-        echo = echo.sput(&self.program.to_string_lossy(), BOLD_CYAN);
+        echo = echo.sput(self.program.to_string_lossy(), BOLD_CYAN);
 
         for arg in &self.args {
-            echo = echo.sput(&arg.to_string_lossy(), BOLD_UNDERLINE);
+            echo = echo.sput(arg.to_string_lossy(), BOLD_UNDERLINE);
         }
 
         echo.end();
@@ -494,7 +498,10 @@ impl Pipeline {
             }
 
             let mut child = cmd.spawn().map_err(|e| Error {
-                message: format!("Failed to spawn command: {}", cmd_def.program.to_string_lossy()),
+                message: format!(
+                    "Failed to spawn command: {}",
+                    cmd_def.program.to_string_lossy()
+                ),
                 source: Some(e),
             })?;
 
@@ -580,21 +587,21 @@ impl Pipeline {
             if let Some(cwd) = &cmd.cwd {
                 echo = echo
                     .sput("cd:", BRIGHT_BLUE)
-                    .sput(&cwd.to_string_lossy(), UNDERLINE_BRIGHT_BLUE);
+                    .sput(cwd.to_string_lossy(), UNDERLINE_BRIGHT_BLUE);
             }
 
             for (key, val) in &cmd.envs {
                 echo = echo
                     .sput("env:", BRIGHT_BLUE)
-                    .sput(&key.to_string_lossy(), UNDERLINE_BRIGHT_BLUE)
+                    .sput(key.to_string_lossy(), UNDERLINE_BRIGHT_BLUE)
                     .put("=")
-                    .sput(&val.to_string_lossy(), UNDERLINE_BRIGHT_BLUE);
+                    .sput(val.to_string_lossy(), UNDERLINE_BRIGHT_BLUE);
             }
 
-            echo = echo.sput(&cmd.program.to_string_lossy(), BOLD_CYAN);
+            echo = echo.sput(cmd.program.to_string_lossy(), BOLD_CYAN);
 
             for arg in &cmd.args {
-                echo = echo.sput(&arg.to_string_lossy(), BOLD_UNDERLINE);
+                echo = echo.sput(arg.to_string_lossy(), BOLD_UNDERLINE);
             }
         }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -14,7 +14,7 @@ pub struct Cmd {
     program: OsString,
     args: Vec<OsString>,
     envs: Vec<(OsString, OsString)>,
-    cwd: Option<PathBuf>,
+    current_dir: Option<PathBuf>,
     input: Option<String>,
     quiet: bool,
 }
@@ -123,7 +123,7 @@ impl Cmd {
             program: program.as_ref().to_os_string(),
             args: Vec::new(),
             envs: Vec::new(),
-            cwd: None,
+            current_dir: None,
             input: None,
             quiet: false,
         }
@@ -169,8 +169,8 @@ impl Cmd {
     }
 
     /// Set the working directory.
-    pub fn cwd(mut self, dir: impl AsRef<Path>) -> Self {
-        self.cwd = Some(dir.as_ref().to_path_buf());
+    pub fn current_dir(mut self, dir: impl AsRef<Path>) -> Self {
+        self.current_dir = Some(dir.as_ref().to_path_buf());
         self
     }
 
@@ -269,8 +269,8 @@ impl Cmd {
             cmd.env(key, val);
         }
 
-        if let Some(cwd) = &self.cwd {
-            cmd.current_dir(cwd);
+        if let Some(current_dir) = &self.current_dir {
+            cmd.current_dir(current_dir);
         }
 
         if capture_output {
@@ -320,10 +320,10 @@ impl Cmd {
         let mut echo = crate::Echo::new();
         echo = echo.sput("cmd", BRIGHT_BLACK);
 
-        if let Some(cwd) = &self.cwd {
+        if let Some(current_dir) = &self.current_dir {
             echo = echo
                 .sput("cd:", BRIGHT_BLUE)
-                .sput(cwd.to_string_lossy(), UNDERLINE_BRIGHT_BLUE);
+                .sput(current_dir.to_string_lossy(), UNDERLINE_BRIGHT_BLUE);
         }
 
         for (key, val) in &self.envs {
@@ -563,8 +563,8 @@ impl Pipeline {
             cmd.env(key, val);
         }
 
-        if let Some(cwd) = &cmd_def.cwd {
-            cmd.current_dir(cwd);
+        if let Some(current_dir) = &cmd_def.current_dir {
+            cmd.current_dir(current_dir);
         }
 
         cmd
@@ -584,10 +584,10 @@ impl Pipeline {
                 echo = echo.sput(pipe_symbol, MAGENTA);
             }
 
-            if let Some(cwd) = &cmd.cwd {
+            if let Some(current_dir) = &cmd.current_dir {
                 echo = echo
                     .sput("cd:", BRIGHT_BLUE)
-                    .sput(cwd.to_string_lossy(), UNDERLINE_BRIGHT_BLUE);
+                    .sput(current_dir.to_string_lossy(), UNDERLINE_BRIGHT_BLUE);
             }
 
             for (key, val) in &cmd.envs {

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -25,7 +25,7 @@ fn test_cmd_builder() {
     let cmd = Cmd::new("ls")
         .arg("-la")
         .env("TEST", "value")
-        .cwd("/tmp")
+        .current_dir("/tmp")
         .quiet();
 
     assert_eq!(cmd.program, OsString::from("ls"));
@@ -34,7 +34,7 @@ fn test_cmd_builder() {
         cmd.envs,
         vec![(OsString::from("TEST"), OsString::from("value"))]
     );
-    assert_eq!(cmd.cwd, Some(PathBuf::from("/tmp")));
+    assert_eq!(cmd.current_dir, Some(PathBuf::from("/tmp")));
     assert!(cmd.quiet);
 }
 
@@ -365,7 +365,10 @@ fn test_large_input() {
 #[test]
 fn test_invalid_working_directory() {
     // Test with non-existent working directory
-    let result = cmd!("pwd").cwd("/nonexistent/directory/path").quiet().run();
+    let result = cmd!("pwd")
+        .current_dir("/nonexistent/directory/path")
+        .quiet()
+        .run();
     assert!(result.is_err());
 }
 
@@ -592,7 +595,7 @@ fn test_builder_pattern_completeness() {
         .args(vec!["arg2", "arg3"])
         .env("VAR1", "value1")
         .env("VAR2", "value2")
-        .cwd("/tmp")
+        .current_dir("/tmp")
         .input("test input")
         .quiet();
 
@@ -614,7 +617,7 @@ fn test_builder_pattern_completeness() {
         cmd.envs[1],
         (OsString::from("VAR2"), OsString::from("value2"))
     );
-    assert_eq!(cmd.cwd, Some(PathBuf::from("/tmp")));
+    assert_eq!(cmd.current_dir, Some(PathBuf::from("/tmp")));
     assert_eq!(cmd.input, Some("test input".to_string()));
     assert!(cmd.quiet);
 }

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -1,9 +1,11 @@
 use super::*;
+use std::ffi::OsString;
+use std::path::PathBuf;
 
 #[test]
 fn test_cmd_new() {
     let cmd = Cmd::new("echo");
-    assert_eq!(cmd.program, "echo");
+    assert_eq!(cmd.program, OsString::from("echo"));
     assert!(cmd.args.is_empty());
     assert!(!cmd.quiet);
 }
@@ -11,8 +13,8 @@ fn test_cmd_new() {
 #[test]
 fn test_cmd_with_args() {
     let cmd = cmd!("echo", "hello", "world");
-    assert_eq!(cmd.program, "echo");
-    assert_eq!(cmd.args, vec!["hello", "world"]);
+    assert_eq!(cmd.program, OsString::from("echo"));
+    assert_eq!(cmd.args, vec![OsString::from("hello"), OsString::from("world")]);
 }
 
 #[test]
@@ -23,10 +25,10 @@ fn test_cmd_builder() {
         .cwd("/tmp")
         .quiet();
 
-    assert_eq!(cmd.program, "ls");
-    assert_eq!(cmd.args, vec!["-la"]);
-    assert_eq!(cmd.envs, vec![("TEST".to_string(), "value".to_string())]);
-    assert_eq!(cmd.cwd, Some("/tmp".to_string()));
+    assert_eq!(cmd.program, OsString::from("ls"));
+    assert_eq!(cmd.args, vec![OsString::from("-la")]);
+    assert_eq!(cmd.envs, vec![(OsString::from("TEST"), OsString::from("value"))]);
+    assert_eq!(cmd.cwd, Some(PathBuf::from("/tmp")));
     assert!(cmd.quiet);
 }
 
@@ -288,35 +290,35 @@ fn test_long_mixed_pipeline() {
 fn test_cmd_parse() {
     // Test basic parsing
     let cmd = Cmd::parse("echo hello world");
-    assert_eq!(cmd.program, "echo");
-    assert_eq!(cmd.args, vec!["hello", "world"]);
+    assert_eq!(cmd.program, OsString::from("echo"));
+    assert_eq!(cmd.args, vec![OsString::from("hello"), OsString::from("world")]);
 
     // Test parsing with multiple spaces
     let cmd = Cmd::parse("ls  -la   /tmp");
-    assert_eq!(cmd.program, "ls");
-    assert_eq!(cmd.args, vec!["-la", "/tmp"]);
+    assert_eq!(cmd.program, OsString::from("ls"));
+    assert_eq!(cmd.args, vec![OsString::from("-la"), OsString::from("/tmp")]);
 
     // Test empty string
     let cmd = Cmd::parse("");
-    assert_eq!(cmd.program, "");
+    assert_eq!(cmd.program, OsString::from(""));
     assert!(cmd.args.is_empty());
 
     // Test single word
     let cmd = Cmd::parse("pwd");
-    assert_eq!(cmd.program, "pwd");
+    assert_eq!(cmd.program, OsString::from("pwd"));
     assert!(cmd.args.is_empty());
 
     // Test with leading/trailing whitespace
     let cmd = Cmd::parse("  echo test  ");
-    assert_eq!(cmd.program, "echo");
-    assert_eq!(cmd.args, vec!["test"]);
+    assert_eq!(cmd.program, OsString::from("echo"));
+    assert_eq!(cmd.args, vec![OsString::from("test")]);
 }
 
 #[test]
 fn test_empty_command_handling() {
     // Test empty program name
     let cmd = Cmd::new("");
-    assert_eq!(cmd.program, "");
+    assert_eq!(cmd.program, OsString::from(""));
     let result = cmd.quiet().run();
     assert!(result.is_err());
 }
@@ -372,7 +374,7 @@ fn test_multiple_environment_variables() {
 fn test_args_method() {
     // Test adding multiple arguments at once
     let cmd = Cmd::new("ls").args(vec!["-l", "-a", "-h"]);
-    assert_eq!(cmd.args, vec!["-l", "-a", "-h"]);
+    assert_eq!(cmd.args, vec![OsString::from("-l"), OsString::from("-a"), OsString::from("-h")]);
 
     // Test with empty iterator
     let cmd = Cmd::new("echo").args(Vec::<&str>::new());
@@ -575,12 +577,12 @@ fn test_builder_pattern_completeness() {
         .input("test input")
         .quiet();
 
-    assert_eq!(cmd.program, "test_program");
-    assert_eq!(cmd.args, vec!["arg1", "arg2", "arg3"]);
+    assert_eq!(cmd.program, OsString::from("test_program"));
+    assert_eq!(cmd.args, vec![OsString::from("arg1"), OsString::from("arg2"), OsString::from("arg3")]);
     assert_eq!(cmd.envs.len(), 2);
-    assert_eq!(cmd.envs[0], ("VAR1".to_string(), "value1".to_string()));
-    assert_eq!(cmd.envs[1], ("VAR2".to_string(), "value2".to_string()));
-    assert_eq!(cmd.cwd, Some("/tmp".to_string()));
+    assert_eq!(cmd.envs[0], (OsString::from("VAR1"), OsString::from("value1")));
+    assert_eq!(cmd.envs[1], (OsString::from("VAR2"), OsString::from("value2")));
+    assert_eq!(cmd.cwd, Some(PathBuf::from("/tmp")));
     assert_eq!(cmd.input, Some("test input".to_string()));
     assert!(cmd.quiet);
 }

--- a/src/cmd/tests.rs
+++ b/src/cmd/tests.rs
@@ -14,7 +14,10 @@ fn test_cmd_new() {
 fn test_cmd_with_args() {
     let cmd = cmd!("echo", "hello", "world");
     assert_eq!(cmd.program, OsString::from("echo"));
-    assert_eq!(cmd.args, vec![OsString::from("hello"), OsString::from("world")]);
+    assert_eq!(
+        cmd.args,
+        vec![OsString::from("hello"), OsString::from("world")]
+    );
 }
 
 #[test]
@@ -27,7 +30,10 @@ fn test_cmd_builder() {
 
     assert_eq!(cmd.program, OsString::from("ls"));
     assert_eq!(cmd.args, vec![OsString::from("-la")]);
-    assert_eq!(cmd.envs, vec![(OsString::from("TEST"), OsString::from("value"))]);
+    assert_eq!(
+        cmd.envs,
+        vec![(OsString::from("TEST"), OsString::from("value"))]
+    );
     assert_eq!(cmd.cwd, Some(PathBuf::from("/tmp")));
     assert!(cmd.quiet);
 }
@@ -291,12 +297,18 @@ fn test_cmd_parse() {
     // Test basic parsing
     let cmd = Cmd::parse("echo hello world");
     assert_eq!(cmd.program, OsString::from("echo"));
-    assert_eq!(cmd.args, vec![OsString::from("hello"), OsString::from("world")]);
+    assert_eq!(
+        cmd.args,
+        vec![OsString::from("hello"), OsString::from("world")]
+    );
 
     // Test parsing with multiple spaces
     let cmd = Cmd::parse("ls  -la   /tmp");
     assert_eq!(cmd.program, OsString::from("ls"));
-    assert_eq!(cmd.args, vec![OsString::from("-la"), OsString::from("/tmp")]);
+    assert_eq!(
+        cmd.args,
+        vec![OsString::from("-la"), OsString::from("/tmp")]
+    );
 
     // Test empty string
     let cmd = Cmd::parse("");
@@ -374,7 +386,14 @@ fn test_multiple_environment_variables() {
 fn test_args_method() {
     // Test adding multiple arguments at once
     let cmd = Cmd::new("ls").args(vec!["-l", "-a", "-h"]);
-    assert_eq!(cmd.args, vec![OsString::from("-l"), OsString::from("-a"), OsString::from("-h")]);
+    assert_eq!(
+        cmd.args,
+        vec![
+            OsString::from("-l"),
+            OsString::from("-a"),
+            OsString::from("-h")
+        ]
+    );
 
     // Test with empty iterator
     let cmd = Cmd::new("echo").args(Vec::<&str>::new());
@@ -578,10 +597,23 @@ fn test_builder_pattern_completeness() {
         .quiet();
 
     assert_eq!(cmd.program, OsString::from("test_program"));
-    assert_eq!(cmd.args, vec![OsString::from("arg1"), OsString::from("arg2"), OsString::from("arg3")]);
+    assert_eq!(
+        cmd.args,
+        vec![
+            OsString::from("arg1"),
+            OsString::from("arg2"),
+            OsString::from("arg3")
+        ]
+    );
     assert_eq!(cmd.envs.len(), 2);
-    assert_eq!(cmd.envs[0], (OsString::from("VAR1"), OsString::from("value1")));
-    assert_eq!(cmd.envs[1], (OsString::from("VAR2"), OsString::from("value2")));
+    assert_eq!(
+        cmd.envs[0],
+        (OsString::from("VAR1"), OsString::from("value1"))
+    );
+    assert_eq!(
+        cmd.envs[1],
+        (OsString::from("VAR2"), OsString::from("value2"))
+    );
     assert_eq!(cmd.cwd, Some(PathBuf::from("/tmp")));
     assert_eq!(cmd.input, Some("test input".to_string()));
     assert!(cmd.quiet);

--- a/src/echo.rs
+++ b/src/echo.rs
@@ -68,8 +68,10 @@ macro_rules! echo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn test_echo_new_normal() {
         // Save original state
         let original = std::env::var("NO_ECHO").ok();
@@ -91,6 +93,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_echo_new_quiet_env() {
         // Save original state
         let original = std::env::var("NO_ECHO").ok();
@@ -236,6 +239,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_echo_macro_with_no_echo_env() {
         // Save original state
         let original = std::env::var("NO_ECHO").ok();
@@ -306,6 +310,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_echo_default() {
         // Save original state
         let original = std::env::var("NO_ECHO").ok();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! // Using the builder pattern
 //! cmd!("grep", "error")
 //!     .arg("logfile.txt")
-//!     .cwd("/var/log")
+//!     .current_dir("/var/log")
 //!     .env("LANG", "C")
 //!     .run()?;
 //! # Ok::<(), Box<dyn std::error::Error>>(())
@@ -180,7 +180,7 @@
 //!
 //! cmd!("grep", "error")
 //!     .arg("logfile.txt")
-//!     .cwd("/var/log")
+//!     .current_dir("/var/log")
 //!     .env("LANG", "C")
 //!     .quiet()
 //!     .run()?;
@@ -250,13 +250,13 @@
 //!     .run()?;
 //!
 //! // Change working directory
-//! cmd!("pwd").cwd("/tmp").run()?;
+//! cmd!("pwd").current_dir("/tmp").run()?;
 //!
 //! // Combine multiple settings
 //! cmd!("make", "install")
 //!     .env("PREFIX", "/usr/local")
 //!     .env("DESTDIR", "/tmp/staging")
-//!     .cwd("./my-project")
+//!     .current_dir("./my-project")
 //!     .run()?;
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
@@ -340,13 +340,13 @@
 //!     .run()?;
 //!
 //! // Change working directory
-//! cmd!("pwd").cwd("/tmp").run()?;
+//! cmd!("pwd").current_dir("/tmp").run()?;
 //!
 //! // Combine multiple settings
 //! cmd!("make", "install")
 //!     .env("PREFIX", "/usr/local")
 //!     .env("DESTDIR", "/tmp/staging")
-//!     .cwd("./my-project")
+//!     .current_dir("./my-project")
 //!     .run()?;
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -86,7 +86,7 @@ fn test_working_directory() {
     let current_dir = std::env::current_dir().unwrap();
     let parent = current_dir.parent().unwrap_or(&current_dir);
 
-    let result = cmd!("pwd").cwd(parent).output().unwrap();
+    let result = cmd!("pwd").current_dir(parent).output().unwrap();
 
     assert_eq!(result.trim(), parent.to_string_lossy());
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -85,7 +85,7 @@ fn run_precommit(verbose: bool) -> Result<()> {
     if !verbose {
         echo!("🧪 Running tests...");
     }
-    cmd!("cargo", "test").cwd(&project_root).run()?;
+    cmd!("cargo", "test").current_dir(&project_root).run()?;
     if !verbose {
         echo!("✅ Tests passed!");
     }
@@ -103,7 +103,7 @@ fn run_precommit(verbose: bool) -> Result<()> {
         "-D",
         "warnings"
     )
-    .cwd(&project_root)
+    .current_dir(&project_root)
     .run()?;
     if !verbose {
         echo!("✅ Clippy checks passed!");
@@ -113,7 +113,7 @@ fn run_precommit(verbose: bool) -> Result<()> {
     if !verbose {
         echo!("🎨 Formatting code...");
     }
-    cmd!("cargo", "fmt").cwd(&project_root).run()?;
+    cmd!("cargo", "fmt").current_dir(&project_root).run()?;
     if !verbose {
         echo!("✅ Code formatted!");
     }
@@ -136,7 +136,7 @@ fn run_ci(verbose: bool) -> Result<()> {
     if !verbose {
         echo!("🎨 Formatting code...");
     }
-    cmd!("cargo", "fmt").cwd(&project_root).run()?;
+    cmd!("cargo", "fmt").current_dir(&project_root).run()?;
     if !verbose {
         echo!("✅ Code formatted!");
     }
@@ -154,7 +154,7 @@ fn run_ci(verbose: bool) -> Result<()> {
         "-D",
         "warnings"
     )
-    .cwd(&project_root)
+    .current_dir(&project_root)
     .run()?;
     if !verbose {
         echo!("✅ Clippy checks passed!");
@@ -165,7 +165,7 @@ fn run_ci(verbose: bool) -> Result<()> {
         echo!("🔍 Running cargo check...");
     }
     cmd!("cargo", "check", "--all-targets")
-        .cwd(&project_root)
+        .current_dir(&project_root)
         .run()?;
     if !verbose {
         echo!("✅ Check passed!");
@@ -175,7 +175,7 @@ fn run_ci(verbose: bool) -> Result<()> {
     if !verbose {
         echo!("🧪 Running tests...");
     }
-    cmd!("cargo", "test").cwd(&project_root).run()?;
+    cmd!("cargo", "test").current_dir(&project_root).run()?;
     if !verbose {
         echo!("✅ Tests passed!");
     }

--- a/xtask/src/readme.rs
+++ b/xtask/src/readme.rs
@@ -50,7 +50,7 @@ pub fn generate_readme_with_options(force: bool) -> Result<()> {
 
     // Generate README using cargo-readme as base
     let base_readme = cmd!("cargo", "readme", "--no-title", "--no-badges")
-        .cwd(&project_root)
+        .current_dir(&project_root)
         .output()?;
 
     // Create enhanced README content


### PR DESCRIPTION
## 概要

このPRは失われた変更を復元し、メソッドをに変更します。

## 変更内容

### 復元された変更
- **PR #7の変更を復元**: OsString/OsStr APIの改善を復元
- 失われたコミットからcherry-pickによる復元

### 新しい変更
- **APIの改善**: メソッドをに名前変更
- **テストの修正**: 環境変数競合を避けるためアトリビュートを追加
- **ドキュメントの更新**: 全ての例でをに変更
- **依存関係の追加**: クレートを追加

## 修正された問題

1. **失われた変更の復元**: 強制プッシュで失われたPR #7の変更を復元
2. **テストの不安定性**: の間欠的な失敗を修正
3. **APIの一貫性**: という明確で一貫した命名

## 変更されたファイル

-  - 依存関係の追加
-  - からへの変更
-  - テストの更新
-  - アトリビュートの追加
-  - ドキュメントの更新
- その他例とテストファイル

## テスト

✅ 全てのユニットテストが成功  
✅ 全ての統合テストが成功  
✅ ドキュメントテストが成功  
✅ Precommitチェックが成功 (clippy + fmt + test)